### PR TITLE
Trimmed NCR and Legion factions to 21 members each

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -91,8 +91,8 @@ Centurion
 	flag = F13CENTURION
 	faction = "Legion"
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the commander of the Centuria and are the direct superior to the Decanii, working with them and your soldiers to ensure that your Garrison is prepared for the coming battle of Hoover Dam. You are to establish yourself within the region in order to defeat the Profligates who would oppose Caesar, while allying with those who would make your Legion stronger."
 	supervisors = "Legate"
 	selection_color = "#ffdddd"
@@ -244,6 +244,7 @@ Decan
 		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/magazine/m10mm_adv=2, \
+		/obj/item/megaphone/cornu=1, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legofficers)
 
@@ -255,8 +256,8 @@ Vexillarius
 	title = "Legion Vexillarius"
 	flag = F13VEXILLARIUS
 	faction = "Legion"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Decanii and the Centurion, acting as a standard bearer for your Centuria. You raise troop morale, relay orders from the Decanii and the Centurion, and rally men when ordered, however, you hold no actual authority over the troops and should instead only relay orders from your superiors."
 	supervisors = "Recruit Decanus and up."
 	exp_requirements = 2100
@@ -290,8 +291,8 @@ Vexillarius
 	title = "Legion Libritor"
 	flag = F13LIBRITOR
 	faction = "Legion"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Veteran Decanus and the Centurion, acting as a loyal soldier of the Centuria, you have the great honour of serving under Caesar in his quest to unite the scattered tribes of The Mojave. You are a gun-toting Libritor, and have been waging war with the Legion for the better part of ten years."
 	supervisors = "Veteran Decanus and up."
 	exp_requirements = 2400
@@ -408,8 +409,8 @@ Legionary
 	title = "Recruit Legionnaire"
 	flag = F13LEGIONARY
 	faction = "Legion"
-	total_positions = 12
-	spawn_positions = 12
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Recruit Decanus and the Centurion, but are expected to follow orders from the Prime and Veteran Decanii as needed. You act as a loyal soldier within the Centuria, you have the great honour of serving under Caesar in his quest to unite the scattered tribes of The Mojave."
 	supervisors = "Recruit Decanus and up."
 	exp_requirements = 300
@@ -443,8 +444,8 @@ Legionary
 	title = "Legion Venator"
 	flag = F13VENATOR
 	faction = "Legion"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Centurion and the Decanii, acting as the eyes of the Centuria you bear the responsibility of obtaining intelligence for your superiors and organizing the Scouts and Explorers to do the same.  As a Venator, there is no failure."
 	supervisors = "Decanii and the Centurion."
 	exp_requirements = 2400
@@ -479,8 +480,8 @@ Legionary
 	title = "Legion Explorer"
 	flag = F13EXPLORER
 	faction = "Legion"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Centurion and the Decanii, acting as the eyes of the Centuria you bear the responsibility of obtaining intelligence for your superiors and organizing the Scouts to do the same."
 	supervisors = "Venators, Decanii and the Centurion."
 	exp_requirements = 1200
@@ -547,8 +548,8 @@ Legionary
 	title = "Camp Follower"
 	flag = F13CAMPFOLLOWER
 	faction = "Legion"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	description = "You answer directly to any member of the Legion, working as a Camp Follower for the Centuria, you bear the great honor of supporting Caesar?s Army in its conquest of the Mojave in whatever capacity required from those whom you serve. You perform any tasks required of you, for you know how to serve the Legion well."
 	supervisors = "the entire legion"
 	exp_requirements = 300

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -61,8 +61,8 @@ Captain
 	flag = F13CAPTAIN
 	head_announce = list("Security")
 	faction = "NCR"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the commanding officer of your company and direct superior to the Veteran Ranger and Lieutenant, coordinating with your staff you must ensure that the objectives of central command are completed to the letter. Working closely with them on logistics, mission planning and special operations with the Rangers, you are here to establish a strong foothold for the NCR within the region."
 	supervisors = "Colonel"
 	req_admin_notify = 1
@@ -339,8 +339,8 @@ Recruit
 	title = "NCR Recruit"
 	flag = F13RECRUIT
 	faction = "NCR"
-	total_positions = 10
-	spawn_positions = 10
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer to the Sergeants or Corporals,  following the chain of command, to your commanding officer, the Captain."
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
@@ -376,8 +376,8 @@ Heavy Trooper
 /datum/job/ncr/f13heavytroop
 	title = "NCR Heavy Trooper"
 	flag = F13HEAVYTROOP
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	faction = "NCR"
 	description = "You are an elite, heavy trooper with the NCR that has years of experience and training under their belt. You are also equivalent to a Sergeant, and as such, can organize lower troops as you see fit to assist in NCR interests and goals throughout the region."
 	supervisors = "Lieutenants and above"
@@ -540,8 +540,8 @@ Recon Ranger
 	title = "NCR Scout Lieutenant"
 	flag = F13SCOUTLT
 	faction = "NCR"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are an officer of the Third Scout Battalion and are entrusted with reconnassaince, sabotage, and destruction of Legion assets.  As a Lieutenant, you are in charge of scout operations in the area."
 	supervisors = "Captain and above"
 	exp_requirements = 720
@@ -581,8 +581,8 @@ Recon Ranger
 	title = "NCR Scout Sergeant"
 	flag = F13SCOUTSSGT
 	faction = "NCR"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are an NCO of the Third Scout Battalion and are entrusted with reconnassaince, sabotage, and destruction of Legion assets.  As a Staff Sergeant, you are second-in-command of the scout forces in the area."
 	supervisors = "Lieutenants and above"
 	selection_color = "#fff5cc"
@@ -621,8 +621,8 @@ Recon Ranger
 	title = "NCR Scout"
 	flag = F13SCOUTCPL
 	faction = "NCR"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 2
+	spawn_positions = 2
 	description = "You are a member of the Third Scout Battalion and are entrusted with reconnassaince, sabotage, and destruction of Legion assets.  As a Corporal, you were selected for your excellence in hit-and-run operations and marksmanship."
 	supervisors = "Sergeants and above"
 	selection_color = "#fff5cc"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -135,10 +135,10 @@ Lieutenant
 	box = null
 
 	/*
-Medic
+Medic, TODO: make into one role (engineer/MO hybrid)
 */
 /datum/job/ncr/f13medic
-	title = "NCR Medical Officer"
+	title = "NCR Support Officer"
 	flag = F13MEDIC
 	faction = "NCR"
 	total_positions = 1
@@ -151,7 +151,7 @@ Medic
 	outfit = /datum/outfit/job/ncr/f13medic
 
 /datum/outfit/job/ncr/f13medic
-	name = "NCR Medical Officer"
+	name = "NCR Support Officer"
 	jobtype = /datum/job/ncr/f13medic
 	chemwhiz = TRUE
 	id		= /obj/item/card/id/dogtag/ncrlieutenant

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -621,8 +621,8 @@ Recon Ranger
 	title = "NCR Scout"
 	flag = F13SCOUTCPL
 	faction = "NCR"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 4
+	spawn_positions = 4
 	description = "You are a member of the Third Scout Battalion and are entrusted with reconnassaince, sabotage, and destruction of Legion assets.  As a Corporal, you were selected for your excellence in hit-and-run operations and marksmanship."
 	supervisors = "Sergeants and above"
 	selection_color = "#fff5cc"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Trimmed legion and NCR factions to 21 members each.
Added the horn to normal decanus.
8 troopers, 4 corporals, 2 sergeants, 4 recon, 2 support, 1 LT for both (their equivalents).

## Motivation and Context
Ren wanted it.

## How Has This Been Tested?
No errors on host. Everything looks in order.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/51462035/120802843-2e961300-c543-11eb-9143-2b3589a1abd6.png)

## Changelog (necessary)
:cl:
tweak: Legion and NCR slots decreased to 21.
/:cl:
